### PR TITLE
Use float64 instead of int64 for memory

### DIFF
--- a/mesos/logging.go
+++ b/mesos/logging.go
@@ -28,7 +28,7 @@ func LogState(state State) {
 	}
 	// add up resource counts from slaves
 	totalCPU := 0.0
-	totalMem := int64(0)
+	totalMem := 0.0
 	for _, slave := range state.Slaves {
 		r := slave.Resources
 		totalCPU += r.CPUs
@@ -37,9 +37,9 @@ func LogState(state State) {
 
 	// actual used/offer amounts come from the framework(s)
 	usedCPU := 0.0
-	usedMem := int64(0)
+	usedMem := 0.0
 	offeredCPU := 0.0
-	offeredMem := int64(0)
+	offeredMem := 0.0
 	for _, framework := range state.Frameworks {
 		for _, offer := range framework.Offers {
 			offeredCPU += offer.CPUs

--- a/mesos/poll_client.go
+++ b/mesos/poll_client.go
@@ -50,7 +50,7 @@ type Slave struct {
 type Resources struct {
 	CPUs  float64 `json:"cpus"`
 	Disk  int64   `json:"disk"`
-	Mem   int64   `json:"mem"`
+	Mem   float64 `json:"mem"`
 	Ports string  `json:"ports"`
 }
 


### PR DESCRIPTION
Json unmarshaling error occurs on the rare occasion the `mem` value is not an integer.

e.g. from mesos-dev: 

`"name":"mesos-visualizer.system","resources":{"cpus":0.1,"disk":0,"mem":102.4,"ports":"[31912-31912]"}`
