### PR TITLE
[INFRA-3218] CircleCI 1.0 -> 2.0 migration cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
     - run: make install_deps
     - run: make build
     - run: make test
-    - run: $HOME/ci-scripts/circleci/report-card $RC_DOCKER_USER $RC_DOCKER_PASS "$RC_DOCKER_EMAIL" $RC_GITHUB_TOKEN
     - run:
         command: |-
           cd /tmp/ && wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
@@ -27,3 +26,4 @@ jobs:
           sudo pip install --upgrade awscli && aws --version
           pip install --upgrade --user awscli
         name: Install awscli for ECR publish
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG; fi;


### PR DESCRIPTION
JIRA: [INFRA-3218](https://clever.atlassian.net/browse/INFRA-3218)

Improve on the initial CircleCI autotranslation:
- add back docker-publish (accidentally removed) 
- rm report-card  (deprecated)



previous: https://github.com/Clever/marathon-stats/pull/30/files
